### PR TITLE
remove NEWPWD from zsh directory hash table on exit

### DIFF
--- a/bd
+++ b/bd
@@ -69,4 +69,5 @@ else
   echo $NEWPWD
   cd "$NEWPWD"
   unset NEWPWD
+  unhash -d NEWPWD
 fi


### PR DESCRIPTION
In zsh, in the shell session, the target directory gets named NEWPWD because zsh saves so called static named directories in a hash tables (`hash -d` to list them). 

This patch removes the NEWPWD entry from the hash table which makes zsh show the correct directory name
