### PR TITLE
Simplify

### DIFF
--- a/bd
+++ b/bd
@@ -44,14 +44,11 @@ newpwd() {
   if [ "$2" = "-s" ]
   then
     NEWPWD=`echo $OLDPWD | sed 's|\(.*/'$3'[^/]*/\).*|\1|'`
-    index=`echo $NEWPWD | awk '{ print index($0,"/'$3'"); }'`
   elif [ "$2" = "-si" ]
   then
     NEWPWD=`echo $OLDPWD | sed 's|\(.*/'$3'[^/]*/\).*|\1|I'`
-    index=`echo $NEWPWD | awk '{ print index(tolower($0),tolower("/'$3'")); }'`
   else
     NEWPWD=`echo $OLDPWD | sed 's|\(.*/'$2'/\).*|\1|'`
-    index=`echo $NEWPWD | awk '{ print index($1,"/'$2'/"); }'`
   fi
 }
 
@@ -66,7 +63,7 @@ else
 
   newpwd "$OLDPWD" "$@"
   
-  if [ $index -eq 0 ]
+  if [ "$NEWPWD" = "$OLDPWD" ]
   then
     echo "No such occurrence."
   fi

--- a/bd
+++ b/bd
@@ -40,15 +40,15 @@ EOF
 }
 
 newpwd() {
-  OLDPWD=$1
+  oldpwd=$1
   if [ "$2" = -s ]
   then
-    NEWPWD=`echo $OLDPWD | sed 's|\(/'$3'[^/]*/\).*|\1|'`
+    NEWPWD=`echo $oldpwd | sed 's|\(/'$3'[^/]*/\).*|\1|'`
   elif [ "$2" = -si ]
   then
-    NEWPWD=`echo $OLDPWD | sed 's|\(/'$3'[^/]*/\).*|\1|I'`
+    NEWPWD=`echo $oldpwd | sed 's|\(/'$3'[^/]*/\).*|\1|I'`
   else
-    NEWPWD=`echo $OLDPWD | sed 's|\(/'$2'/\).*|\1|'`
+    NEWPWD=`echo $oldpwd | sed 's|\(/'$2'/\).*|\1|'`
   fi
 }
 
@@ -59,11 +59,11 @@ elif [ $# -eq 1 -a "$1" = -s ]
 then
   usage_error
 else
-  OLDPWD=`pwd`
+  oldpwd=`pwd`
 
-  newpwd "$OLDPWD" "$@"
+  newpwd "$oldpwd" "$@"
   
-  if [ "$NEWPWD" = "$OLDPWD" ]
+  if [ "$NEWPWD" = "$oldpwd" ]
   then
     echo "No such occurrence."
   fi

--- a/bd
+++ b/bd
@@ -43,12 +43,12 @@ newpwd() {
   OLDPWD=$1
   if [ "$2" = "-s" ]
   then
-    NEWPWD=`echo $OLDPWD | sed 's|\(.*/'$3'[^/]*/\).*|\1|'`
+    NEWPWD=`echo $OLDPWD | sed 's|\(/'$3'[^/]*/\).*|\1|'`
   elif [ "$2" = "-si" ]
   then
-    NEWPWD=`echo $OLDPWD | sed 's|\(.*/'$3'[^/]*/\).*|\1|I'`
+    NEWPWD=`echo $OLDPWD | sed 's|\(/'$3'[^/]*/\).*|\1|I'`
   else
-    NEWPWD=`echo $OLDPWD | sed 's|\(.*/'$2'/\).*|\1|'`
+    NEWPWD=`echo $OLDPWD | sed 's|\(/'$2'/\).*|\1|'`
   fi
 }
 

--- a/bd
+++ b/bd
@@ -46,7 +46,7 @@ newpwd() {
     NEWPWD=`echo $oldpwd | sed 's|\(/'$3'[^/]*/\).*|\1|'`
   elif [ "$2" = -si ]
   then
-    NEWPWD=`echo $oldpwd | sed 's|\(/'$3'[^/]*/\).*|\1|I'`
+    NEWPWD=`echo $oldpwd | perl -pe 's|(/'$3'[^/]*/).*|$1|i'`
   else
     NEWPWD=`echo $oldpwd | sed 's|\(/'$2'/\).*|\1|'`
   fi

--- a/bd
+++ b/bd
@@ -41,10 +41,10 @@ EOF
 
 newpwd() {
   OLDPWD=$1
-  if [ "$2" = "-s" ]
+  if [ "$2" = -s ]
   then
     NEWPWD=`echo $OLDPWD | sed 's|\(/'$3'[^/]*/\).*|\1|'`
-  elif [ "$2" = "-si" ]
+  elif [ "$2" = -si ]
   then
     NEWPWD=`echo $OLDPWD | sed 's|\(/'$3'[^/]*/\).*|\1|I'`
   else
@@ -55,7 +55,7 @@ newpwd() {
 if [ $# -eq 0 ]
 then
   usage_error
-elif [ $# -eq 1 -a "$1" = "-s" ]
+elif [ $# -eq 1 -a "$1" = -s ]
 then
   usage_error
 else

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -29,39 +29,32 @@ sample=/home/user/project/src/org/main/site/utils/file/reader/whatever
 # test run with no args
 newpwd $sample
 assertEquals $sample $NEWPWD
-assertEquals 0 $index
 
 # test run with exact match
 newpwd $sample src
 assertEquals /home/user/project/src/ $NEWPWD
-assertEquals 19 $index
 
 # test run with prefix but no -s so not found
 newpwd $sample sr
 assertEquals $sample $NEWPWD
-assertEquals 0 $index
 
 # test run with prefix found
 newpwd $sample -s sr
 assertEquals /home/user/project/src/ $NEWPWD
-assertEquals 19 $index
 
 # test run with prefix not found because case sensitive
 newpwd $sample -s Sr
 assertEquals $sample $NEWPWD
-assertEquals 0 $index
 
 # test run with prefix found thanks to -si
 newpwd $sample -si Sr
 assertEquals /home/user/project/src/ $NEWPWD
-assertEquals 19 $index
 
 sample='/home/user/my project/src'
 
 # test run with space in dirname
 newpwd "$sample" -s my
 assertEquals '/home/user/my project/' "$NEWPWD"
-assertEquals 11 $index
 
 echo
 [[ $failure = 0 ]] && printf $green || printf $red


### PR DESCRIPTION
A few improvements:
- simplified the core logic (`newpwd`)
- replaced the `sed` used by `-si` with `perl`, to make it work in BSD too
- renamed `OLDPWD` to `oldpwd`, to avoid messing with the *real* `OLDPWD` automatically set by the shell when you change directories