### PR TITLE
Simplify core logic and support BSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ You can take advantage of that by combining <code>\`bd \<letter(s)\>\`</code> wi
 **Thanks:**
 * [@jaysh](https://github.com/jaysh) - Autocomplete support
 * [@rmhsilva](https://github.com/rmhsilva) - Case-Insensitive directory name matching
-* [@janosgyerik](https://github.com/janosgyerik) - Test cases
+* [@janosgyerik](https://github.com/janosgyerik) - Test cases, BSD support
 
 ---
 

--- a/bd
+++ b/bd
@@ -48,7 +48,7 @@ newpwd() {
   then
     NEWPWD=`echo $oldpwd | perl -pe 's|(/'$3'[^/]*/).*|$1|i'`
   else
-    NEWPWD=`echo $oldpwd | sed 's|\(/'$2'/\).*|\1|'`
+    NEWPWD=`echo $oldpwd | sed 's|\(.*/'$2'/\).*|\1|'`
   fi
 }
 

--- a/bd
+++ b/bd
@@ -35,7 +35,6 @@ So in the case of the given example, it would be
 
 For case-insensitive directory matching, using -si instead of -s, after bd:
      '. bd -si'
-Note: this requires GNU sed to be installed (BSD sed on OS X 10.8.2 won't work).
 EOF
 }
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -58,7 +58,7 @@ assertEquals '/home/user/my project/' "$NEWPWD"
 
 # should take to closest matching dir
 newpwd /tmp/a/b/c/d/a/b a
-assertEquals /tmp/a/b/c/d/a "$NEWPWD"
+assertEquals /tmp/a/b/c/d/a/ "$NEWPWD"
 
 echo
 [[ $failure = 0 ]] && printf $green || printf $red

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -56,6 +56,10 @@ sample='/home/user/my project/src'
 newpwd "$sample" -s my
 assertEquals '/home/user/my project/' "$NEWPWD"
 
+# should take to closest matching dir
+newpwd /tmp/a/b/c/d/a/b a
+assertEquals /tmp/a/b/c/d/a "$NEWPWD"
+
 echo
 [[ $failure = 0 ]] && printf $green || printf $red
 echo "Tests run: $total ($success success, $failure failed)"


### PR DESCRIPTION
The improvements:

- simplified the core logic (`newpwd`)
- replaced the `sed` used by `-si` with `perl`, to make it work in BSD too (dropped the special note about BSD)
- renamed `OLDPWD` to `oldpwd`, to avoid messing with the *real* `OLDPWD` automatically set by the shell when you change directories