### PR TITLE
Fix issue with bash completion on Mac OSX

### DIFF
--- a/bash_completion.d/bd
+++ b/bash_completion.d/bd
@@ -7,7 +7,7 @@ _bd()
     # Current argument on the command line.
     local cur=${COMP_WORDS[COMP_CWORD]}
     # Available directories to autcomplete to.
-    local completions=$( pwd | sed 's|/|\n|g' )
+    local completions=$( pwd | sed 's|/|\'$'\n|g' )
 
     COMPREPLY=( $(compgen -W "$completions" -- $cur) )
 }


### PR DESCRIPTION
This had to do with sed on mac not properly expanding newlines.  Tested on CentOS, and does not seem to break anything