### PR TITLE
Remove current dir from bash completion

### DIFF
--- a/bash_completion.d/bd
+++ b/bash_completion.d/bd
@@ -7,7 +7,7 @@ _bd()
     # Current argument on the command line.
     local cur=${COMP_WORDS[COMP_CWORD]}
     # Available directories to autcomplete to.
-    local completions=$( pwd | sed 's|/|\'$'\n|g' )
+    local completions=$( dirname `pwd` | sed 's|/|\'$'\n|g' )
 
     COMPREPLY=( $(compgen -W "$completions" -- $cur) )
 }


### PR DESCRIPTION
Bash completion also displays current dir. This is not necessary and if selected throws error.