### PR TITLE
POSIX compatibility, for bash alternatives (eg. dash, mksh, etc)

### DIFF
--- a/bd
+++ b/bd
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /bin/sh
 usage_error () {
   cat << EOF
 ------------------------------------------------------------------
@@ -33,10 +33,12 @@ newpwd() {
   esac
 }
 
+for last; do true; done
+
 if [ $# -eq 0 ]
 then
   usage_error
-elif [ "${@: -1}" = -v ]
+elif [ $last = -v ]
 then
   usage_error
 else
@@ -53,3 +55,6 @@ else
   fi
   unset NEWPWD
 fi
+
+unset last
+


### PR DESCRIPTION
May be related to commit b89095930f3b56c61395589aa389080f82a839d4, I propose returning to POSIX shell compatibility instead of commiting to supporting only bash