### PR TITLE
The automcomplete suggestions occur in order of the directory structu…

### DIFF
--- a/bash_completion.d/bd
+++ b/bash_completion.d/bd
@@ -11,4 +11,4 @@ _bd()
 
     COMPREPLY=( $(compgen -W "$completions" -- $cur) )
 }
-complete -F _bd bd
+complete -o nosort -F _bd bd


### PR DESCRIPTION
#35 
The auto-complete suggestions are shown in directory nesting order and not in alphabetical order....
eg: /home/owner/github/project/src

```
owner:/home/owner/github/project/src $ bd <tab-key><tab-key>

home  owner  github  project  

```