### PR TITLE
Replace cat+heredoc with echo

### DIFF
--- a/bd
+++ b/bd
@@ -15,8 +15,7 @@ help_msg () {
 }
 
 usage_error () {
-  cat << EOF
-------------------------------------------------------------------
+  echo "------------------------------------------------------------------
 Name: bd
 Version: 1.03
 
@@ -26,9 +25,7 @@ Description: Go back to a specified directory up in the hierarchy.
 ------------------------------------------------------------------
 How to use:
 
-Please refer https://github.com/vigneshwaranr/bd
-
-EOF
+Please refer https://github.com/vigneshwaranr/bd"
   return 1
 }
 


### PR DESCRIPTION
Replaces the `cat` and heredoc in `usage_error()` with the builtin `echo` with a quoted argument spanning multiple lines

Achieves the same output without calling an external program.